### PR TITLE
Extra outputs export improvement and cleanup

### DIFF
--- a/R/results_summary_f.R
+++ b/R/results_summary_f.R
@@ -10,10 +10,10 @@
 #'
 #' @examples
 #' \dontrun{
-#' summary_results_det(results$output_sim[[1]][[1]],arm="int")
+#' summary_results_det(results[[1]][[1]],arm="int")
 #' }
 
-summary_results_det <- function(out = results$output_sim[[1]][[1]], arm=NULL){
+summary_results_det <- function(out = results[[1]][[1]], arm=NULL){
   arm <- ifelse(is.null(arm),out$arm_list[1],arm)
 
   other_arm_list <- out$arm_list[out$arm_list!=arm] #For any other treatment that is not the reference one, add the reference arm costs/lys/qalys
@@ -112,10 +112,10 @@ data <- data.frame()
 #'
 #' @examples
 #' \dontrun{
-#' summary_results_sim(results$output_sim[[1]], arm="int")
+#' summary_results_sim(results[[1]], arm="int")
 #' }
 
-summary_results_sim <- function(out = results$output_sim[[1]], arm=NULL){
+summary_results_sim <- function(out = results[[1]], arm=NULL){
 
   arm <- ifelse(is.null(arm),out[[1]]$arm_list[1],arm)
 
@@ -219,7 +219,7 @@ summary_results_sim <- function(out = results$output_sim[[1]], arm=NULL){
 #'
 #' @examples
 #' \dontrun{
-#' extract_psa_result(results$output_sim[[1]],"costs","int")
+#' extract_psa_result(results[[1]],"costs","int")
 #' }
 
 extract_psa_result <- function(x, element,arm) {
@@ -253,13 +253,13 @@ extract_psa_result <- function(x, element,arm) {
 ceac_des <- function(wtp, results, interventions = NULL, sensitivity_used = 1) {
 
   if (is.null(interventions)) {
-    interventions <- results$output_sim[[sensitivity_used]][[1]]$arm_list
+    interventions <- results[[sensitivity_used]][[1]]$arm_list
   }
 
   nmb <- data.frame()
   for (comparator in interventions) {
 
-     nmb_i <- t(as.matrix(sapply(wtp, function(wtp_i) wtp_i * extract_psa_result(results$output_sim[[sensitivity_used]],"total_qalys",comparator)$value - extract_psa_result(results$output_sim[[sensitivity_used]],"total_costs",comparator)$value)))
+     nmb_i <- t(as.matrix(sapply(wtp, function(wtp_i) wtp_i * extract_psa_result(results[[sensitivity_used]],"total_qalys",comparator)$value - extract_psa_result(results[[sensitivity_used]],"total_costs",comparator)$value)))
 
      if (nrow(nmb_i)>1) {
        nmb_i <- t(nmb_i)
@@ -310,14 +310,14 @@ ceac_des <- function(wtp, results, interventions = NULL, sensitivity_used = 1) {
 evpi_des <- function(wtp, results, interventions = NULL, sensitivity_used = 1) {
 
   if (is.null(interventions)) {
-    interventions <- results$output_sim[[sensitivity_used]][[1]]$arm_list
+    interventions <- results[[sensitivity_used]][[1]]$arm_list
   }
 
 
   nmb <- data.frame()
   for (comparator in interventions) {
 
-    nmb_i <- t(as.matrix(sapply(wtp, function(wtp_i) wtp_i * extract_psa_result(results$output_sim[[sensitivity_used]],"total_qalys",comparator)$value - extract_psa_result(results$output_sim[[sensitivity_used]],"total_costs",comparator)$value)))
+    nmb_i <- t(as.matrix(sapply(wtp, function(wtp_i) wtp_i * extract_psa_result(results[[sensitivity_used]],"total_qalys",comparator)$value - extract_psa_result(results[[sensitivity_used]],"total_costs",comparator)$value)))
 
     if (nrow(nmb_i)>1) {
       nmb_i <- t(nmb_i)

--- a/R/run_sim.R
+++ b/R/run_sim.R
@@ -31,7 +31,9 @@
 #' `run_sim_parallel` only runs multiple-core at the simulation level.
 #' `run_sim` uses only-single core.
 #' `run_sim` can be more efficient if using only one simulation (e.g., deterministic),
-#'  while `run_sim_parallel` will be more efficient if the number of simulations is >1 (e.g., PSA). 
+#'  while `run_sim_parallel` will be more efficient if the number of simulations is >1 (e.g., PSA).
+#'  A list of protected objects that should not be used by the user as input names to avoid the risk of overwriting them is as follows:
+#'  c("arm", "arm_list", "categories_for_export", "cur_evtlist", "curtime", "evt", "i", "prevtime", "sens", "simulation", "sens_name_used","list_env","uc_lists") 
 #'
 #' @examples
 #' \dontrun{
@@ -236,7 +238,7 @@ run_sim <- function(arm_list=c("int","noint"),
   # Export results ----------------------------------------------------------
 
 
-  results <- list(output_sim=output_sim)
+  results <- output_sim
 
   return(results)
 

--- a/R/run_sim_parallel.R
+++ b/R/run_sim_parallel.R
@@ -34,6 +34,8 @@
 #' `run_sim` allows to run single-core.
 #' `run_sim_parallel` allows to use multiple-core at the simulation level,
 #' making it more efficient for a large number of simulations relative to `run_sim` (e.g., for  PSA).
+#' A list of protected objects that should not be used by the user as input names to avoid the risk of overwriting them is as follows:
+#' c("arm", "arm_list", "categories_for_export", "cur_evtlist", "curtime", "evt", "i", "prevtime", "sens", "simulation", "sens_name_used","list_env","uc_lists") 
 #' 
 #' @examples
 #' \dontrun{
@@ -84,7 +86,8 @@ run_sim_parallel <- function(arm_list=c("int","noint"),
 
 # Set-up basics -----------------------------------------------------------
 
-  registerDoParallel(ncores)
+  cl <- parallel::makeCluster(ncores)
+  registerDoParallel(cl)
   
   arm_list <- arm_list #this is done as otherwise there are problems passing arguments from function to function
   
@@ -231,8 +234,6 @@ run_sim_parallel <- function(arm_list=c("int","noint"),
         final_output$merged_df$sensitivity <- sens
       }
   
-      # output_sim[[sens]][[simulation]] <- final_output
-  
       return(list(final_output))
       
       print(paste0("Time to run simulation ", simulation,": ",  round(proc.time()[3]- start_time[3] , 2 ), "s"))
@@ -243,12 +244,13 @@ run_sim_parallel <- function(arm_list=c("int","noint"),
   }
   print(paste0("Total time to run: ",  round(proc.time()[3]- start_time_simulations[3] , 2), "s"))
   rm(list=ls(name=foreach:::.foreachGlobals), pos=foreach:::.foreachGlobals) 
+  parallel::stopCluster(cl)
   
 
   # Export results ----------------------------------------------------------
 
 
-  results <- list(output_sim=output_sim)
+  results <- output_sim
 
   return(results)
 

--- a/vignettes/articles/example_uncertainty.Rmd
+++ b/vignettes/articles/example_uncertainty.Rmd
@@ -393,12 +393,12 @@ for (sample_size in sample_sizes) {
   )) 
 
   #We're extracting the overall ICER/ICUR and also costs/qalys/lys for the "noint" intervention
-  loop_df <- rbind(extract_psa_result(results$output_sim[[1]],"total_costs","noint"),
-                   extract_psa_result(results$output_sim[[1]],"total_lys","noint"),
-                   extract_psa_result(results$output_sim[[1]],"total_qalys","noint"),
-                   extract_psa_result(results$output_sim[[1]],"total_costs","int"),
-                   extract_psa_result(results$output_sim[[1]],"total_lys","int"),
-                   extract_psa_result(results$output_sim[[1]],"total_qalys","int"))
+  loop_df <- rbind(extract_psa_result(results[[1]],"total_costs","noint"),
+                   extract_psa_result(results[[1]],"total_lys","noint"),
+                   extract_psa_result(results[[1]],"total_qalys","noint"),
+                   extract_psa_result(results[[1]],"total_costs","int"),
+                   extract_psa_result(results[[1]],"total_lys","int"),
+                   extract_psa_result(results[[1]],"total_qalys","int"))
   
     loop_df <- rbind(loop_df, loop_df %>%
                      spread(arm,value) %>%
@@ -488,12 +488,12 @@ for (sample_size in sample_sizes) {
   ))
 
   #We're extracting the overall ICER/ICUR and also costs/qalys/lys for the "noint" intervention
-  loop_psa_df <- rbind(extract_psa_result(results$output_sim[[1]],"total_costs","noint"),
-                   extract_psa_result(results$output_sim[[1]],"total_lys","noint"),
-                   extract_psa_result(results$output_sim[[1]],"total_qalys","noint"),
-                   extract_psa_result(results$output_sim[[1]],"total_costs","int"),
-                   extract_psa_result(results$output_sim[[1]],"total_lys","int"),
-                   extract_psa_result(results$output_sim[[1]],"total_qalys","int"))
+  loop_psa_df <- rbind(extract_psa_result(results[[1]],"total_costs","noint"),
+                   extract_psa_result(results[[1]],"total_lys","noint"),
+                   extract_psa_result(results[[1]],"total_qalys","noint"),
+                   extract_psa_result(results[[1]],"total_costs","int"),
+                   extract_psa_result(results[[1]],"total_lys","int"),
+                   extract_psa_result(results[[1]],"total_qalys","int"))
   
     loop_psa_df <- rbind(loop_psa_df, loop_psa_df %>%
                      spread(arm,value) %>%
@@ -571,13 +571,9 @@ ggplot(ceac_out,aes(x=wtp,y=prob_best,group=comparator,col=comparator)) +
   theme(plot.title = element_text(hjust = 0.5))
 
 
-ceaf <- ceac_out %>%
-  group_by(wtp) %>%
-  mutate(max_prob=prob_best==max(prob_best)) %>%
-  filter(max_prob==TRUE)
 
-ggplot(ceaf,aes(x=wtp,y=prob_best,group=comparator,col=comparator)) +
-  geom_line()+
+ggplot(ceac_out,aes(x=wtp,y=prob_best,group=comparator,col=comparator)) +
+  geom_step()+
   xlab("Willingness to Pay") +
   ylab("Probability of being cost-effective")+
   theme_bw() +

--- a/vignettes/example_eBC.Rmd
+++ b/vignettes/example_eBC.Rmd
@@ -438,11 +438,11 @@ Once the model has been run, we can use the results and summarize them using the
 ```{r post-processing_summary}
 
 
-summary_results_det(results$output_sim[[1]][[1]]) #will print the last simulation!
+summary_results_det(results[[1]][[1]]) #will print the last simulation!
 
-summary_results_sim(results$output_sim[[1]])
+summary_results_sim(results[[1]])
 
-psa_ipd <- bind_rows(map(results$output_sim[[1]], "merged_df")) 
+psa_ipd <- bind_rows(map(results[[1]], "merged_df")) 
 
 psa_ipd[1:10,] %>%
   kable() %>%

--- a/vignettes/example_ipd.Rmd
+++ b/vignettes/example_ipd.Rmd
@@ -343,9 +343,9 @@ Once the model has been run, we can use the results and summarize them using the
 
 ```{r post-processing_summary}
 
-summary_results_det(results$output_sim[[1]][[1]]) #will print the last simulation!
+summary_results_det(results[[1]][[1]]) #will print the last simulation!
 
-psa_ipd <- bind_rows(map(results$output_sim[[1]], "merged_df")) 
+psa_ipd <- bind_rows(map(results[[1]], "merged_df")) 
 
 psa_ipd[1:10,] %>%
   kable() %>%

--- a/vignettes/example_markov.Rmd
+++ b/vignettes/example_markov.Rmd
@@ -235,11 +235,11 @@ Once the model has been run, we can use the results and summarize them using the
 
 ```{r post-processing_summary}
 
-summary_results_det(results$output_sim[[1]][[1]]) #will print the last simulation!
+summary_results_det(results[[1]][[1]]) #will print the last simulation!
 
-psa_ipd_simple <- bind_rows(map(results$output_sim[[1]], "merged_df")) %>% select(-trace) %>% distinct() 
+psa_ipd_simple <- bind_rows(map(results[[1]], "merged_df")) %>% select(-trace) %>% distinct() 
 
-psa_ipd <- bind_rows(map(results$output_sim[[1]], "merged_df")) 
+psa_ipd <- bind_rows(map(results[[1]], "merged_df")) 
 
 trace_t <- psa_ipd %>% mutate(state = rep(seq(1:4),62)) %>% select(arm,trace,state,evttime) 
 
@@ -258,10 +258,10 @@ life_years %>%
   kable() %>%
   kable_styling(bootstrap_options = c("striped", "hover", "condensed", "responsive"))
 
-results$output_sim[[1]][[1]][["total_lys_int"]] <- life_years$ly_final[life_years$arm=="int"]
-results$output_sim[[1]][[1]][["total_lys_noint"]] <- life_years$ly_final[life_years$arm=="noint"]
+results[[1]][[1]][["total_lys_int"]] <- life_years$ly_final[life_years$arm=="int"]
+results[[1]][[1]][["total_lys_noint"]] <- life_years$ly_final[life_years$arm=="noint"]
 
-summary_results_det(results$output_sim[[1]][[1]]) #will print the last simulation!
+summary_results_det(results[[1]][[1]]) #will print the last simulation!
 
 ```
 

--- a/vignettes/example_ssd.Rmd
+++ b/vignettes/example_ssd.Rmd
@@ -206,11 +206,11 @@ Once the model has been run, we can use the results and summarize them using the
 ```{r post-processing_summary}
 
 
-summary_results_det(results$output_sim[[1]][[1]]) #will print the last simulation!
+summary_results_det(results[[1]][[1]]) #will print the last simulation!
 
-summary_results_sim(results$output_sim[[1]])
+summary_results_sim(results[[1]])
 
-psa_ipd <- bind_rows(map(results$output_sim[[1]], "merged_df")) 
+psa_ipd <- bind_rows(map(results[[1]], "merged_df")) 
 
 psa_ipd[1:10,] %>%
   kable() %>%
@@ -235,7 +235,7 @@ We now use the data output to plot the histograms/densities of the simulation.
 
 ```{r post-processing_plots1, fig.width=10, fig.height=8}
 
-data_plot <- results$output_sim[[1]][[1]]$merged_df %>%
+data_plot <- results[[1]][[1]]$merged_df %>%
   filter(evtname != "sick") %>%
   group_by(arm,evtname,simulation) %>%
   mutate(median = median(evttime)) %>%
@@ -348,7 +348,7 @@ results <- run_sim(
 We briefly check below that indeed the engine has been changing the corresponding parameter value.
 ```{r dsa_check}
 
-data_sensitivity <- bind_rows(map_depth(results$output_sim,2, "merged_df"))
+data_sensitivity <- bind_rows(map_depth(results,2, "merged_df"))
 
 #Check mean value across iterations as PSA is off
 data_sensitivity %>% group_by(sensitivity) %>% summarise_at(c("util.sick","util.sicker","cost.sick","cost.sicker","cost.int","coef_noint","HR_int"),mean)
@@ -388,7 +388,7 @@ results <- run_sim_parallel(
 We briefly check below that indeed the engine has been changing the corresponding parameter value.
 ```{r dsa_check_psa}
 
-data_sensitivity <- bind_rows(map_depth(results$output_sim,2, "merged_df"))
+data_sensitivity <- bind_rows(map_depth(results,2, "merged_df"))
 
 #Check mean value across iterations as PSA is off
 data_sensitivity %>% group_by(sensitivity) %>% summarise_at(c("util.sick","util.sicker","cost.sick","cost.sicker","cost.int","coef_noint","HR_int"),mean)


### PR DESCRIPTION
-Export now considers whether output is numeric and of length 1 to be summarized as well as part of the aggregate outcomes (non IPD)

-Small improvements into parallel code to clarify use of cluster to consider Windows vs Linux use 
-Nesting of outcomes has been reduced by one as there is no need anymore 
-Notes clarifying how extra outputs are displayed (in compute_outputs function and what objects should be protected (in run_sim function)